### PR TITLE
Add python workflow

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,0 +1,56 @@
+name: "Check Python"
+
+on:
+  workflow_call:
+    inputs:
+      typecheckMustPass:
+        description: "If set to true, type checking must pass"
+        default: true
+        type: boolean
+      lintingMustPass:
+        description: "If set to true, linting must pass"
+        default: true
+        type: boolean
+      testsMustPass:
+        description: "If set to true, testing must pass"
+        default: true
+        type: boolean
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+
+      - name: Install poetry
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Check black formatting
+        run: poetry run black . --check
+
+      - name: Check isort formatting
+        run: poetry run isort . --check
+
+      - name: Check types
+        if: ${{ inputs.typecheckMustPass }}
+        run: poetry run mypy .
+
+      - name: Linting
+        if: ${{ inputs.lintingMustPass }}
+        # Refernce: https://stackoverflow.com/a/63044665/8175935
+        run: poetry run pylint $(git ls-files '*.py')
+
+      - name: Run tests
+        if: ${{ inputs.testsMustPass }}
+        run: poetry run pytest

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -3,6 +3,10 @@ name: "Check Python"
 on:
   workflow_call:
     inputs:
+      pydocstyleMustPass:
+        description: "If set to true, pydocstyle must pass"
+        default: true
+        type: boolean
       typecheckMustPass:
         description: "If set to true, type checking must pass"
         default: true
@@ -41,8 +45,9 @@ jobs:
 
       - name: Check isort formatting
         run: poetry run isort . --check
+
       - name: Check pydocstyle
-        if: ${{ pydocstyleMustPass }}
+        if: ${{ inputs.pydocstyleMustPass }}
         run: poetry run pydocstyle .
 
       - name: Check types

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -41,6 +41,9 @@ jobs:
 
       - name: Check isort formatting
         run: poetry run isort . --check
+      - name: Check pydocstyle
+        if: ${{ pydocstyleMustPass }}
+        run: poetry run pydocstyle .
 
       - name: Check types
         if: ${{ inputs.typecheckMustPass }}


### PR DESCRIPTION
Checks
1.  black formatting
2.  isort formatting 
3.  types (optional)
4. linting (optional)
5. testing (optional)

Type checking, linting and testing are optional for now as they do not all pass for every python repo. They are enabled by default but can be disabled by the following flags
- `typecheckMustPass`
- `lintingMustPass`
- `testsMustPass`

Example: https://github.com/daiseeai/pyutils/pull/9/checks
