### PR TITLE
feat: add `pythonVersion` as input to workflow. Sets default.

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -19,6 +19,10 @@ on:
         description: "If set to true, testing must pass"
         default: true
         type: boolean
+      pythonVersion:
+        description: "Supply Python version for workflow"
+        default: "3.9"
+        type: string
 
 jobs:
   build:
@@ -36,7 +40,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: ${{ inputs.pythonVersion }}
           cache: "poetry"
 
       - name: Install dependencies


### PR DESCRIPTION
Just a quick one. Relates to #3, #4 and #5.

Not quite a full CICD matrix. Couldn't find an easy to pass `array` / `list` type of `python-versions` to the workflow as would be needed see: https://github.com/daiseeai/workflows/pull/3#discussion_r1174732522.

Going with this, can call in a matrix flow if required on the downstream repos.

This is necessary for https://github.com/daiseeai/pycanonicalisation/pull/17 (https://github.com/daiseeai/pycanonicalisation/issues/14) as wanting to run the CICD with `python3.10`.

To this end need a way to specify a python version which is not `3.9` for the CICD flow. 