### PR TITLE
lint: `isort` improvements, `workingDirectory` as input

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -50,7 +50,7 @@ jobs:
         run: poetry run black . --check --diff
 
       - name: Check isort formatting
-        run: poetry run isort . --check --diff
+        run: poetry run isort . --check --diff --profile=black
 
       - name: Check pydocstyle
         if: ${{ inputs.pydocstyleMustPass }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -23,11 +23,18 @@ on:
         description: "Supply Python version for workflow"
         default: "3.9"
         type: string
+      workingDirectory:
+        description: "Working directory for workflow"
+        default: "."
+        type: string
 
 jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.workingDirectory }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
As can be seen on https://github.com/daiseeai/pyscript-adherence/pull/15 when running `isort` and `black` together there can be compatibility issues.  See the last two commit CI on https://github.com/daiseeai/pyscript-adherence/pull/15 for more info...

Adding `--profile=black` makes `isort` play nicely with `black`