### PR TITLE
Fix

### DIFF
--- a/.github/workflows/deploy_aws_ecs.yaml
+++ b/.github/workflows/deploy_aws_ecs.yaml
@@ -46,6 +46,7 @@ jobs:
         with:
           role-to-assume: ${{ inputs.role-to-assume }}
           aws-region: ${{ inputs.aws-region }}
+          role-session-name: deploying-${{ inputs.service }}-to-${{ inputs.environment }}
 
       - name: Download Task Definition From AWS
         run: |

--- a/.github/workflows/deploy_aws_ecs.yaml
+++ b/.github/workflows/deploy_aws_ecs.yaml
@@ -22,14 +22,6 @@ on:
         description: "The name of the container to deploy"
         required: true
         type: string
-      role-to-assume:
-        description: "The role to assume"
-        required: true
-        type: string
-      aws-region:
-        description: "The AWS region"
-        required: true
-        type: string
 
 jobs:
   Deployment:
@@ -44,9 +36,9 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: ${{ inputs.role-to-assume }}
-          aws-region: ${{ inputs.aws-region }}
-          role-session-name: deploying-${{ inputs.service }}-to-${{ inputs.environment }}
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-session-name: deploying-${{ inputs.service }}
 
       - name: Download Task Definition From AWS
         run: |


### PR DESCRIPTION
Turns out you cannot set `environment: dev1` when calling a reusable workflow. So the environment must be set in the reusable workflow file.