### PR TITLE
feat: add `inputs.codeCoverageFailUnder` to rank coverage.

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -19,6 +19,14 @@ on:
         description: "If set to true, testing must pass"
         default: true
         type: boolean
+      codeCoverageFailUnder:
+        description: "Combined with testsMustPass tests will fail if code coverage is under XX%"
+        default: 100
+        type: number
+      codeCoverageProjectName:
+        description: "Combined with codeCoverageFailUnder --cov=project_name"
+        default: ""
+        type: string
       pythonVersion:
         description: "Supply Python version for workflow"
         default: "3.9"
@@ -73,5 +81,9 @@ jobs:
         run: poetry run pylint $(git ls-files '*.py')
 
       - name: Run tests
-        if: ${{ inputs.testsMustPass }}
+        if: ${{ inputs.testsMustPass && inputs.codeCoverageFailUnder == 0 }}
         run: poetry run pytest
+
+      - name: Run tests and compare code coverage
+        if: ${{ inputs.testsMustPass && inputs.codeCoverageFailUnder != 0 }}
+        run: poetry run pytest --cov=$${{ inputs.codeCoverageProjectName }} --cov-fail-under=${{ inputs.codeCoverageFailUnder }}                                              ─╯poetry run pytest --cov=agent_management_system --cov-report term-missing -vv

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -21,6 +21,9 @@ on:
         type: boolean
       codeCoverageFailUnder:
         description: "Combined with testsMustPass tests will fail if code coverage is under XX%"
+        # pytest-cov must be in the poetry env to use this coverage.
+        # set to 0 to skip coverage checking.
+        # Will only run if testsMustPass=true.
         default: 100
         type: number
       codeCoverageProjectName:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -89,4 +89,4 @@ jobs:
 
       - name: Run tests and compare code coverage
         if: ${{ inputs.testsMustPass && inputs.codeCoverageFailUnder != 0 }}
-        run: poetry run pytest --cov=$${{ inputs.codeCoverageProjectName }} --cov-fail-under=${{ inputs.codeCoverageFailUnder }}
+        run: poetry run pytest --cov=${{ inputs.codeCoverageProjectName }} --cov-fail-under=${{ inputs.codeCoverageFailUnder }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -86,4 +86,4 @@ jobs:
 
       - name: Run tests and compare code coverage
         if: ${{ inputs.testsMustPass && inputs.codeCoverageFailUnder != 0 }}
-        run: poetry run pytest --cov=$${{ inputs.codeCoverageProjectName }} --cov-fail-under=${{ inputs.codeCoverageFailUnder }}                                              ─╯poetry run pytest --cov=agent_management_system --cov-report term-missing -vv
+        run: poetry run pytest --cov=$${{ inputs.codeCoverageProjectName }} --cov-fail-under=${{ inputs.codeCoverageFailUnder }}


### PR DESCRIPTION
As part of https://github.com/daiseeai/agent_management_system/issues/6 wanting to adapt this workflow to allow passing of a `codeCoverage` metric. This will enable the unit tests to drop if the code coverage drops below XX%.

In the case of `agent_management_system` I would want to set this to `100%`.

* have set the default value of this to `100%`.
* If a user does not want this to be enabled they will simply need to set this to `0%`.
* Will not break backwards comparability as all existing repos reference a previous commit hash of this repo.

Additional considerations:
* Could be worth considering some of the following toolings:
    * https://about.codecov.io/blog/python-code-coverage-using-github-actions-and-codecov/
    * https://about.codecov.io/
    * https://coveralls.io/
* Without using some form of pricing OR something such as https://github.com/marketplace/actions/pytest-coverage-comment I could think of a nice way to directly integrate this coverage reporting into a Readme or so.
* Ideally (if @ryan-keswick or so gives the 👍 I could use the above mentioned action).
* This could then comment a coverage report on our PRs and update the readme with coverage on merge. 
* Happy to add the above action to this PR just wanted to gain thoughts first.