### PR TITLE
[python]: use of `boto3` in unit tests. Support for reusable workflow.

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -19,6 +19,14 @@ on:
         description: "If set to true, testing must pass"
         default: true
         type: boolean
+      # Dummy variables required for testing using boto3
+      # Are configurable in the case we need to change these.
+      AWS_DEFAULT_REGION:
+        default: us-east-1
+        type: string
+      LOG_LEVEL:
+        default: debug
+        type: string
       codeCoverageFailUnder:
         description: "Combined with testsMustPass tests will fail if code coverage is under XX%"
         # pytest-cov must be in the poetry env to use this coverage.
@@ -38,6 +46,14 @@ on:
         description: "Working directory for workflow"
         default: "."
         type: string
+
+env:
+  # This is so that boto stops complaining,
+  # the tests should not actually connect to AWS
+  # if you need that then use `moto`
+  AWS_DEFAULT_REGION: ${{ inputs.AWS_DEFAULT_REGION }}
+  # This is for the logger to capture all logs
+  LOG_LEVEL: ${{ inputs.LOG_LEVEL }}
 
 jobs:
   build:


### PR DESCRIPTION
For more information on why this _could_ be useful here see:
* [this failed CI run](https://github.com/daiseeai/customers/actions/runs/5949803487/job/16136335499)
* https://github.com/daiseeai/customers/pull/544 the last few commits of this PR.
* GH Actions docs: https://docs.github.com/en/actions/learn-github-actions/contexts#env-context, https://docs.github.com/en/actions/learn-github-actions/variables, https://docs.github.com/en/actions/using-workflows/reusing-workflows

I tried to parse through all of these quickly and look for a nice way to define the `env` vars out of the workflow however AFAIK they will not persist through to the `uses`/reusable workflow. 

Wasn't sure if a `bool` of `awsVarsInProject` or another way to initialize these would be useful. Could just simply set to the dummy variables and not pass them as inputs as I don't think this will do any harm to other workflows.

Happy to discuss further.


## Ref
```
Any environment variables set in an env context defined at the workflow level in the caller workflow are not propagated to the called workflow. For more information, see "Variables" and "Contexts."
```
https://docs.github.com/en/actions/using-workflows/reusing-workflows