### PR TITLE
Version Bump

### DIFF
--- a/.github/workflows/deploy_aws_ecs.yaml
+++ b/.github/workflows/deploy_aws_ecs.yaml
@@ -66,7 +66,7 @@ jobs:
           image: ${{ inputs.registry}}/${{ inputs.image }}:${{ inputs.tag }}
 
       - name: Deploy to AWS
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           task-definition: ${{ steps.update-task-definition.outputs.task-definition }}
           service: ${{ inputs.service }}


### PR DESCRIPTION
Bumps the version of `amazon-ecs-deploy-task-definition` to match the most recent which can be seen [here](https://github.com/aws-actions/amazon-ecs-deploy-task-definition/blob/master/README.md#usage).