### PR TITLE
[`lint_hs`]: Bump to LTS 22.27 (Reimplements: #14)

### DIFF
--- a/.github/workflows/lint_hs.yaml
+++ b/.github/workflows/lint_hs.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: haskell-actions/hlint-setup@v2
         with:
-          version: "3.10"
+          version: "3.6.1"
 
       - uses: haskell-actions/hlint-run@v2
         with:

--- a/.github/workflows/lint_hs.yaml
+++ b/.github/workflows/lint_hs.yaml
@@ -31,7 +31,7 @@ jobs:
       #    ghc-lib-parser that corresponds to the GHC version. Hackage has this
       #    information: https://hackage.haskell.org/package/fourmolu
       #
-      #    For GHC 9.6, this yields:
+      #    For GHC 9.6.5, this yields:
       #
       #        - 0.14.0.0
 

--- a/.github/workflows/lint_hs.yaml
+++ b/.github/workflows/lint_hs.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: haskell-actions/hlint-setup@v2
         with:
-          version: "3.6"
+          version: "3.10"
 
       - uses: haskell-actions/hlint-run@v2
         with:

--- a/.github/workflows/lint_hs.yaml
+++ b/.github/workflows/lint_hs.yaml
@@ -34,6 +34,14 @@ jobs:
       #    For GHC 9.6.5, this yields:
       #
       #        - 0.14.0.0
+      # Example of bumping versions here.
+      # * Check `resolver` `lts` version in `types.call/snapshot.yaml`
+      # * Use this in the below commands to work out what version of `hlint` and `fourmolu` to use.
+      #
+      # GHC: curl -s "https://www.stackage.org/lts-{DESIRED_VERSION}" | grep -o "ghc-[0-9.]*"
+      # hlint: curl -s "https://www.stackage.org/lts-{DESIRED_VERSION}" | grep -o "hlint-[0-9.]*"
+      # fourmolu: curl -s "https://www.stackage.org/lts-{DESIRED_VERSION}" | grep -o "fourmolu-[0-9.]*"
+      #
 
 
       - uses: haskell-actions/run-fourmolu@v9

--- a/.github/workflows/lint_hs.yaml
+++ b/.github/workflows/lint_hs.yaml
@@ -35,7 +35,7 @@ jobs:
       #
       #        - 0.14.0.0
       # Example of bumping versions here.
-      # * Check `resolver` `lts` version in `types.call/snapshot.yaml`
+      # * Check `resolver` `lts` version in `snapshot.yaml`
       # * Use this in the below commands to work out what version of `hlint` and `fourmolu` to use.
       #
       # GHC: curl -s "https://www.stackage.org/lts-{DESIRED_VERSION}" | grep -o "ghc-[0-9.]*"


### PR DESCRIPTION
* In https://github.com/daiseeai/workflows/pull/14 the `versions` used were bumped to `3.6`
* However this never worked.

# Investigation
```sh
❯ curl -s "https://api.github.com/repos/ndmitchell/hlint/releases/tags/v3.6" | jq -r '.assets[] | .name'
❯
```
* Produces `null` output. Empty array.
* Thus [this action](https://github.com/haskell-actions/hlint-setup) will fail with a 404.
* As seen on `scoring-service`: https://github.com/daiseeai/scoring-service/actions/runs/16186851742/job/45694461211

# Suggested Fix. 
* Took https://github.com/daiseeai/workflows/pull/14 as a base
* Checked the [current LTS](https://github.com/daiseeai/types.call/blob/79c4b7fae53149b867924b970291b2e328f6c023/snapshot.yaml#L1): `lts-22.27`
* Checked what versions we can use here. (see below commands).

## What's Changed
* Bumps `hlint` to `3.6.1`

# Testing
* Will test on `scoring-service`.
* IF this works will bump for [all repos](https://github.com/search?q=org%3Adaiseeai+daiseeai%2Fworkflows%2F.github%2Fworkflows%2Flint_hs.yaml&type=code) that use the previous commit here...



# Appendix 
<img width="762" alt="image" src="https://github.com/user-attachments/assets/157713e4-8feb-459a-97bb-4fd14d56a3f9" />

## Version checks
## `hlint`
```sh
❯ curl -s "https://www.stackage.org/lts-22.27" | grep -o "hlint-[0-9.]*"
hlint-3.6.1
hlint-3.6.1
``` 

## `fourmolu`
```sh
❯ curl -s "https://www.stackage.org/lts-22.27" | grep -o "fourmolu-[0-9.]*"
fourmolu-0.14.0.0
fourmolu-0.14.0.0
```

## `ghc`
```sh
❯ curl -s "https://www.stackage.org/lts-22.27" | grep -o "ghc-[0-9.]*"
ghc-9.6.5
ghc-9.6.5
...
...
```